### PR TITLE
Added option to specify the android devices certificate name and MAC to avoid an SSL handshake issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,44 @@ In addition to commands you can send URLs to open apps registered to handle them
 
 See [demo.py](https://github.com/tronikos/androidtvremote2/blob/main/src/demo.py)
 
+If you get an error: `ssl.SSLError: [SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:1131)`
+then you need to find the android devices certificate name and mac manually by running:
+
+```
+openssl s_client -connect <ANDROID TV IP>:6467 -prexit -state 2>/dev/null | grep "issuer="
+```
+
+You are looking for details of the certificate a few examples below.
+
+Your MAC is the bit after the last `/` and the device name is the bit between the '/' before the MAC.
+
+Example line to look for on a Humax Aura box:
+```
+issuer=CN = atvremote/fvp4kgtr/fvp4kgtr/FVP-4KGTR/AB:CD:12:34:56:78
+```
+So in this example mac is `AB:CD:12:34:56:78` and the device name is `FVP-4KGTR`
+
+
+Example from Sony Bravia TV:
+```
+issuer=CN = atvremote/BRAVIA_ATV2_EU/BRAVIA_ATV2/BRAVIA 4K GB/AB:CD:12:34:56:78
+```
+So in this example mac is `AB:CD:12:34:56:78` and the device name is `BRAVIA 4K GB`
+
+
+Example from a Philips TV:
+```
+issuer=dnQualifier = PH9M_EA_5599/PH9M_EA_5599/TPM191E, CN = atvremote/44:D8:78:89:08:62
+issuer=dnQualifier = PH9M_EA_5599/PH9M_EA_5599/TPM191E, CN = atvremote/44:D8:78:89:08:62
+```
+
+So in this example mac is `AB:CD:12:34:56:78` and the device name is `atvremote`
+
+Pass these as arguments to demo:
+```
+python demo.py --server-name "FVP-4KGTR" --server-mac "AB:CD:12:34:56:78"
+```
+
 ## Development environment
 
 ```sh

--- a/src/demo.py
+++ b/src/demo.py
@@ -135,8 +135,9 @@ async def _host_from_zeroconf(timeout: float) -> str:
     return input("Enter IP address of Android TV to connect to: ").split(":")[0]
 
 
-async def _pair(remote: AndroidTVRemote):
-    name, mac = await remote.async_get_name_and_mac()
+async def _pair(remote: AndroidTVRemote, name: str = None, mac: str = None):
+    if name is None or mac is None:
+        name, mac = await remote.async_get_name_and_mac()
     if (
         input(
             f"Do you want to pair with {remote.host} {name} {mac}"
@@ -183,6 +184,15 @@ async def _main():
         default=3,
     )
     parser.add_argument(
+        "--server-name",
+        help="Retrieved from the server certificate",
+    )
+    parser.add_argument(
+        "--server-mac",
+        help="Retrieved from the server certificate",
+    )
+
+    parser.add_argument(
         "-v", "--verbose", help="enable verbose logging", action="store_true"
     )
     args = parser.parse_args()
@@ -195,7 +205,7 @@ async def _main():
 
     if await remote.async_generate_cert_if_missing():
         _LOGGER.info("Generated new certificate")
-        await _pair(remote)
+        await _pair(remote, args.server_name, args.server_mac)
 
     while True:
         try:


### PR DESCRIPTION
On my Sony TV, Philips TV and Huma Aura box (all Android 9 devices but I don't know if that is the reason) I was getting an SSL Handshake error when trying to get the devices certificate name and mac address.

Instead of trying to automate this I've provided parameters to pass into the demo script and instructions in the README in how to get these values manually.