### PR TITLE
Reduce max reconnect interval

### DIFF
--- a/src/androidtvremote2/androidtv_remote.py
+++ b/src/androidtvremote2/androidtv_remote.py
@@ -237,7 +237,7 @@ class AndroidTVRemote:
                     self._on_is_available_updated(True)
                     break
                 except CannotConnect as exc:
-                    delay_seconds = min(2 * delay_seconds, 300)
+                    delay_seconds = min(2 * delay_seconds, 30)
                     LOGGER.debug(
                         "Couldn't reconnect to %s. Will retry in %s seconds. Error: %s",
                         self.host,


### PR DESCRIPTION
As I said earlier, two out of three of my devices lose network connection when they go to sleep. If, after a long idle time, the device is turned on, the integration updates the state for as much as 5 minutes. This is a very very long period to use integration in automations. For example, the old Android TV integration restored the connection within 15-30 seconds.